### PR TITLE
Tweak end of block label

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/default/Configuration_adv.h
+++ b/Marlin/src/config/default/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Anet/A2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A2/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A2plus/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1287,7 +1287,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Cartesio/Configuration_adv.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-8/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Einstart-S/Configuration_adv.h
+++ b/Marlin/src/config/examples/Einstart-S/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Felix/Configuration_adv.h
+++ b/Marlin/src/config/examples/Felix/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Formbot/T-Rex_2+/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/T-Rex_2+/Configuration_adv.h
@@ -1286,7 +1286,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -1281,7 +1281,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/MakerParts/Configuration_adv.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1287,7 +1287,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/RigidBot/Configuration_adv.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/SCARA/Configuration_adv.h
+++ b/Marlin/src/config/examples/SCARA/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/TheBorg/Configuration_adv.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/Marlin/src/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1292,7 +1292,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1281,7 +1281,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1281,7 +1281,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -1281,7 +1281,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1281,7 +1281,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/delta/generic/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration_adv.h
@@ -1281,7 +1281,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1281,7 +1281,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
@@ -1286,7 +1286,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1281,7 +1281,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/makibox/Configuration_adv.h
+++ b/Marlin/src/config/examples/makibox/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1279,7 +1279,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 

--- a/Marlin/src/config/examples/wt150/Configuration_adv.h
+++ b/Marlin/src/config/examples/wt150/Configuration_adv.h
@@ -1280,7 +1280,7 @@
    */
   #define TMC_ADV() {  }
 
-#endif // HAS_TRINAMIC // TMC2130, TMC2208
+#endif // HAS_TRINAMIC
 
 // @section L6470
 


### PR DESCRIPTION
For consistency, match the block end label to the block start.